### PR TITLE
Expose Distinguished Names in searches

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -22,3 +22,12 @@ impl From<rasn_ldap::PartialAttribute> for Attribute {
         }
     }
 }
+
+/// An entry found during the search
+#[derive(Clone, Debug, PartialEq)]
+pub struct SearchEntry {
+    /// The name of the object found (Distinguished Name)
+    pub dn: String,
+    /// The attributes associated with the object
+    pub attributes: Attributes,
+}


### PR DESCRIPTION
# Description

resolves #1 

I added new type `SearchEntry` which contains Attributes with object DN.

# Breaking changes

- `LdapClient.search_one()`, `LdapClient.search()` and `LdapClient.search_paged()` returns `SearchEntry` instead of `Attributes`